### PR TITLE
修复文件服务七牛云同名文件无法上传覆盖的问题

### DIFF
--- a/modules/file/service_qiniu.go
+++ b/modules/file/service_qiniu.go
@@ -33,9 +33,8 @@ func (s *ServiceQiniu) UploadFile(filePath string, contentType string, copyFileW
 
 	bucket := qiniuCfg.BucketName
 	putPolicy := storage.PutPolicy{
-		Scope: bucket,
+		Scope: fmt.Sprintf("%s:%s", bucket, filePath),
 	}
-	putPolicy.Expires = 7200 //示例2小时有效期
 	mac := auth.New(qiniuCfg.AccessKey, qiniuCfg.SecretKey)
 	upToken := putPolicy.UploadToken(mac)
 


### PR DESCRIPTION
修复使用七牛云文件服务时因为七牛云上传策略只能新增不能修改替换文件，导致的无法更换群头像问题。

![image](https://github.com/TangSengDaoDao/TangSengDaoDaoServer/assets/20333663/4f6cfeb5-d1fe-445a-9ba3-68b01b118fce)
