### PR TITLE
feat:增加Dockerfile.ghcr和GitHub Actions工作流以支持多架构构建

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,28 @@
+name: 🧹 GHCR Cleanup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔍 Cleanup GHCR
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: ${{ github.event.repository.name }}
+          delete-untagged: true
+          older-than: 30 days
+          delete-ghost-images: true
+          delete-partial-images: true
+          delete-orphaned-images: true
+          validate: true
+          log-level: info
+          dry-run: false

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -1,0 +1,76 @@
+name: 🐳 Docker (Multi-Arch)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+    tags: [ "*" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🐹 Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+       
+      - name: 🧱 Build binaries
+        run: |
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o linux_amd64
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o linux_arm64
+
+      - name: 🛠️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
+          use: true
+
+      - name: 🔐 Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏷️ Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+
+      - name: 🚀 Build and push Docker image (Multi-Arch)
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.ghcr
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -1,0 +1,13 @@
+FROM debian:bookworm-slim
+
+ARG TARGETARCH
+ENV WORKDIR /app
+WORKDIR $WORKDIR
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    update-ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 linux_${TARGETARCH} main
+CMD /app/main


### PR DESCRIPTION
### ghcr-cleanup.yml
自动清理 GitHub Container Registry (GHCR) 中的容器镜像

### ghcr.yml
用于在推送（push）、PR 提交（pull_request）或手动触发时，构建并推送一个多架构的 Docker 镜像（支持 linux/amd64 和 linux/arm64），使用自定义命名的 Dockerfile.ghcr，并将生成的镜像推送到 GitHub Container Registry（GHCR），同时基于仓库 meta 信息自动生成镜像标签（如版本号、分支名、PR 编号等）

### Dockerfile.ghcr
debian:bookworm-slim 体积适中，基于 glibc，兼容性和稳定性更好；alpine 极小，但基于 musl，历史上 DNS 解析有过不稳定问题，在高并发环境可能出错，因此更适合对体积要求极高、可接受额外测试的场景。