### PR TITLE
fix: prevent path traversal in getKeepAliveVideo endpoint

### DIFF
--- a/modules/common/api.go
+++ b/modules/common/api.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"net/http"
 	"strconv"
 	"time"
@@ -107,8 +108,10 @@ func (cn *Common) getKeepAliveVideo(c *wkhttp.Context) {
 		c.ResponseError(errors.New("视频名称不能为空"))
 		return
 	}
+	// Prevent path traversal by extracting only the base filename
+	videoName = filepath.Base(videoName)
 	c.Header("Content-Type", "video/mp4")
-	videoPath := fmt.Sprintf("assets/resources/keepalive/%s", videoName)
+	videoPath := filepath.Join("assets", "resources", "keepalive", videoName)
 	videoBytes, err := ioutil.ReadFile(videoPath)
 	if err != nil {
 		cn.Error("视频不存在", zap.Error(err))


### PR DESCRIPTION
## Summary

Prevent path traversal in the `getKeepAliveVideo` endpoint by sanitizing the `video_name` query parameter.

## Problem

The `getKeepAliveVideo` function directly interpolates user input into a file path:

```go
videoName := c.Query("video_name")
videoPath := fmt.Sprintf("assets/resources/keepalive/%s", videoName)
videoBytes, err := ioutil.ReadFile(videoPath)
```

An attacker can read arbitrary files: `GET /common/keepalive/video?video_name=../../../etc/passwd`

## Fix

- Use `filepath.Base(videoName)` to strip directory components
- Use `filepath.Join` for safe path construction

## Impact

- **Type**: Path Traversal / Arbitrary File Read (CWE-22)
- **Risk**: Read any file on the server including configs and credentials
- **OWASP**: A01:2021 — Broken Access Control